### PR TITLE
Ensure password validation uses consistent 8–20 character rule

### DIFF
--- a/app/src/main/java/com/vhkfoundation/activity/ActivityChangePassword.java
+++ b/app/src/main/java/com/vhkfoundation/activity/ActivityChangePassword.java
@@ -143,9 +143,19 @@ public class ActivityChangePassword extends AppCompatActivity implements WebServ
     private void updatePassword(){
         int response = 0;
         response = CheckValidation.emptyEditTextError(edTexts, edTextsError);
-        if (!getEditextValue(et_new_password).equals(getEditextValue(et_confirm_password))) {
-            response++;
-            customToast.showCustomToast(svContext, "Password not matching", customToast.ToastyError);
+        if (response == 0) {
+            if (!CheckValidation.isPasswordValid(getEditextValue(et_new_password))) {
+                response++;
+                et_new_password.setError("Password must be 8-20 characters and include letters and numbers");
+            }
+            if (!CheckValidation.isPasswordValid(getEditextValue(et_confirm_password))) {
+                response++;
+                et_confirm_password.setError("Password must be 8-20 characters and include letters and numbers");
+            }
+            if (!getEditextValue(et_new_password).equals(getEditextValue(et_confirm_password))) {
+                response++;
+                customToast.showCustomToast(svContext, "Password not matching", customToast.ToastyError);
+            }
         }
         if (response == 0) {
             lstUploadData = new LinkedList<>();

--- a/app/src/main/java/com/vhkfoundation/activity/ActivityForgotPassword.java
+++ b/app/src/main/java/com/vhkfoundation/activity/ActivityForgotPassword.java
@@ -192,9 +192,19 @@ public class ActivityForgotPassword extends AppCompatActivity {
                 edTexts,
                 new String[]{"Enter New Password","Enter Confirm Password"});
 
-        if (!getEditextValue(et_new_password).equals(getEditextValue(et_confirm_password))) {
-            response++;
-            customToast.showCustomToast(svContext, "Password not matching", customToast.ToastyError);
+        if (response == 0) {
+            if (!CheckValidation.isPasswordValid(getEditextValue(et_new_password))) {
+                response++;
+                et_new_password.setError("Password must be 8-20 characters and include letters and numbers");
+            }
+            if (!CheckValidation.isPasswordValid(getEditextValue(et_confirm_password))) {
+                response++;
+                et_confirm_password.setError("Password must be 8-20 characters and include letters and numbers");
+            }
+            if (!getEditextValue(et_new_password).equals(getEditextValue(et_confirm_password))) {
+                response++;
+                customToast.showCustomToast(svContext, "Password not matching", customToast.ToastyError);
+            }
         }
 
         if(response == 0){

--- a/app/src/main/java/com/vhkfoundation/activity/ActivityRegister.java
+++ b/app/src/main/java/com/vhkfoundation/activity/ActivityRegister.java
@@ -171,11 +171,21 @@ public class ActivityRegister extends AppCompatActivity implements WebServiceLis
                         "Enter Your Name", "Enter Your Email Id","Enter Your Phone","Enter Your Password","Enter Your Password"
                 });
 
-        if (!(binding.etPassword.getText().equals(binding.etPassword2.getText()))){
-            binding.etPassword.setError("Enter Same Password");
-            binding.etPassword2.setError("Enter Same Password");
+        if (response == 0) {
+            if (!CheckValidation.isPasswordValid(getEditextValue(et_password))) {
+                response++;
+                et_password.setError("Password must be 8-20 characters and include letters and numbers");
+            }
+            if (!CheckValidation.isPasswordValid(getEditextValue(et_password2))) {
+                response++;
+                et_password2.setError("Password must be 8-20 characters and include letters and numbers");
+            }
+            if (!binding.etPassword.getText().toString().equals(binding.etPassword2.getText().toString())){
+                response++;
+                binding.etPassword.setError("Enter Same Password");
+                binding.etPassword2.setError("Enter Same Password");
+            }
         }
-
 
         if(response==0){
             if(strReferral.equalsIgnoreCase("Yes")){

--- a/app/src/main/java/com/vhkfoundation/commonutility/CheckValidation.java
+++ b/app/src/main/java/com/vhkfoundation/commonutility/CheckValidation.java
@@ -108,24 +108,24 @@ public class CheckValidation {
     }
 
     public static boolean isPasswordLengthCorrect(EditText text) {
-        if (text.getText() != null && text.getText().toString().trim().length() >= 8) {
-            return true;
-        } else {
-            return false;
+        if (text.getText() != null) {
+            int length = text.getText().toString().trim().length();
+            return length >= 8 && length <= 20;
         }
+        return false;
     }
 
+    /**
+     * Validate password to ensure it is 8-20 characters long and contains both
+     * letters and numbers.
+     */
     public static boolean isPasswordValid(String number) {
-        //String regexStr = "^([0-9\\(\\)\\/\\+ \\-]*)$";
-        String regexStr = " (?!^[0-9]*$)(?!^[a-zA-Z]*$)^([a-zA-Z0-9]{8,20})$";
-
-        if (number.length() < 6 || number.length() > 13 /*|| number.matches(regexStr) == false*/) {
-            //	Log.d("tag", "Number is not valid");
+        String regexStr = "^(?=.*[0-9])(?=.*[a-zA-Z])[a-zA-Z0-9]{8,20}$";
+        if (number == null || number.length() < 8 || number.length() > 20 || !number.matches(regexStr)) {
             return false;
         }
         return true;
     }
-
     public static long currentTimeInMillis() {
         Time time = new Time();
         time.setToNow();


### PR DESCRIPTION
## Summary
- enforce 8–20 character password policy with letters and digits in `CheckValidation`
- validate new password length and content in change, registration, and forgot screens

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a8b63d0834832aae9f4101fcc52bef