### PR TITLE
Handle null in URL validation

### DIFF
--- a/app/src/main/java/com/vhkfoundation/commonutility/CheckValidation.java
+++ b/app/src/main/java/com/vhkfoundation/commonutility/CheckValidation.java
@@ -92,15 +92,13 @@ public class CheckValidation {
     }
 
     public static boolean urlValidate(String url) {
+        if (url == null || url.isEmpty()) {
+            return false;
+        }
         String expression = ".*(youtube|youtu.be).*";
         Pattern pattern = Pattern.compile(expression, Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(url);
-        if (matcher.matches()) {
-            return true;
-        } else if (url.equals("")) {
-            return false;
-        }
-        return false;
+        return matcher.matches();
     }
 
     public static String getEditTextValue(EditText text) {


### PR DESCRIPTION
## Summary
- avoid null pointer in CheckValidation.urlValidate by checking for null or empty input
- simplify url validation logic

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a8a7aac7f0832aa37c80da17d33ac3