### PR TITLE
Refresh input and button styles

### DIFF
--- a/app/src/main/res/drawable/bg_button.xml
+++ b/app/src/main/res/drawable/bg_button.xml
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ripple  xmlns:android="http://schemas.android.com/apk/res/android"
-     android:color="@color/orange">
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/orange">
     <item android:id="@android:id/background">
         <shape android:shape="rectangle">
-            <gradient
-                android:startColor="@color/orange"
-                android:centerColor="@color/orange"
-                android:endColor="@color/orange"
-                android:angle="270" />
-            <corners android:radius="@dimen/dp_30"/>
+            <solid android:color="@color/orange" />
+            <corners android:radius="@dimen/dp_12" />
         </shape>
     </item>
-</ripple >
+</ripple>
 
 
 

--- a/app/src/main/res/drawable/bg_button_blue.xml
+++ b/app/src/main/res/drawable/bg_button_blue.xml
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ripple  xmlns:android="http://schemas.android.com/apk/res/android"
-     android:color="@color/blue">
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/blue">
     <item android:id="@android:id/background">
         <shape android:shape="rectangle">
-            <gradient
-                android:startColor="@color/blue"
-                android:centerColor="@color/blue"
-                android:endColor="@color/blue"
-                android:angle="270" />
-            <corners android:radius="@dimen/dp_30"/>
+            <solid android:color="@color/blue" />
+            <corners android:radius="@dimen/dp_12" />
         </shape>
     </item>
-</ripple >
+</ripple>
 
 
 

--- a/app/src/main/res/drawable/bg_edittext.xml
+++ b/app/src/main/res/drawable/bg_edittext.xml
@@ -3,6 +3,6 @@
     <stroke
         android:width="@dimen/dp_1"
         android:color="@color/orange" />
-    <corners android:radius="@dimen/dp_20" />
-    <solid android:color="@color/light_orange" />
+    <corners android:radius="@dimen/dp_12" />
+    <solid android:color="@color/white" />
 </shape>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppEditText" parent="android:Widget.EditText">
+        <item name="android:background">@drawable/bg_edittext</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textColorHint">@color/gray</item>
+        <item name="android:paddingLeft">@dimen/dp_10</item>
+        <item name="android:paddingRight">@dimen/dp_10</item>
+    </style>
+
+    <style name="AppButton" parent="Widget.MaterialComponents.Button">
+        <item name="android:background">@drawable/bg_button</item>
+        <item name="android:textColor">@color/white</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -15,6 +15,8 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <!-- Customize your theme here. -->
+        <item name="editTextStyle">@style/AppEditText</item>
+        <item name="buttonStyle">@style/AppButton</item>
     </style>
 
     <style name="Theme.VHKFoundation.NoActionBar">


### PR DESCRIPTION
## Summary
- modernize text input background and button drawables
- introduce shared widget styles and reference them in the app theme

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a8b8d60aa4832a8f90e2a2ae4748c6